### PR TITLE
Add pybind11 bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,29 @@ find /host -name '*.cpp' -or -name '*.hpp' | xargs clang-format -i
 The style follows the one from
 [`ament_clang_format`](https://github.com/ament/ament_lint/blob/master/ament_clang_format/doc/index.rst).
 
+## Python bindings
+
+Minimal Python bindings are provided via `zivid_camera_pybind`.
+The module exposes a `ZividCamera` class that can be used to
+perform captures directly from Python:
+
+```python
+import zivid_camera_pybind
+
+camera = zivid_camera_pybind.ZividCamera()
+if camera.is_connected():
+    camera.capture()
+    camera.capture_2d()
+    camera.capture_and_save("/tmp/frame.zdf")
+    yaml = camera.capture_assistant_suggest_settings()
+    print(camera.camera_info_model_name(), camera.camera_info_serial_number())
+```
+
+The module exposes the same capture-related services as the C++ API:
+`capture()`, `capture_2d()`, `capture_and_save()`,
+`capture_assistant_suggest_settings()`, `camera_info_model_name()`,
+`camera_info_serial_number()` and `is_connected()`.
+
 ## License
 
 This project is licensed under BSD 3-clause license, see the [LICENSE](LICENSE) file for details.

--- a/zivid_camera/CMakeLists.txt
+++ b/zivid_camera/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(zivid_camera LANGUAGES CXX)
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+set(PYTHON_INSTALL_DIR lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -25,6 +28,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(image_transport REQUIRED)
+find_package(pybind11_vendor REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -100,6 +104,11 @@ install(
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
 )
+
+pybind11_add_module(zivid_camera_pybind src/zivid_camera_pybind.cpp)
+target_link_libraries(zivid_camera_pybind PRIVATE ${ZIVID_DRIVER_COMPONENT_NAME})
+ament_target_dependencies(zivid_camera_pybind rclcpp std_srvs zivid_interfaces)
+install(TARGETS zivid_camera_pybind DESTINATION ${PYTHON_INSTALL_DIR})
 
 
 if(BUILD_TESTING)

--- a/zivid_camera/include/zivid_camera/zivid_camera.hpp
+++ b/zivid_camera/include/zivid_camera/zivid_camera.hpp
@@ -172,6 +172,7 @@ private:
   IntrinsicsSource intrinsicsSource() const;
 
   friend class ControllerInterface;
+  friend class ZividCameraPrivateAccess;
 
   std::map<std::string, ColorSpace> color_space_name_value_map_;
   std::map<std::string, IntrinsicsSource> intrinsics_source_name_value_map_;

--- a/zivid_camera/package.xml
+++ b/zivid_camera/package.xml
@@ -21,7 +21,9 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <build_depend>pybind11_vendor</build_depend>
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>pybind11_vendor</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/zivid_camera/src/zivid_camera_pybind.cpp
+++ b/zivid_camera/src/zivid_camera_pybind.cpp
@@ -1,0 +1,121 @@
+#include <pybind11/pybind11.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/trigger.hpp>
+#include <zivid_interfaces/srv/is_connected.hpp>
+#include <zivid_interfaces/srv/capture_and_save.hpp>
+#include <zivid_interfaces/srv/capture_assistant_suggest_settings.hpp>
+#include <zivid_interfaces/srv/camera_info_model_name.hpp>
+#include <zivid_interfaces/srv/camera_info_serial_number.hpp>
+
+#include "zivid_camera/zivid_camera.hpp"
+
+namespace py = pybind11;
+using namespace zivid_camera;
+
+class ZividCameraPrivateAccess
+{
+public:
+  static void capture(ZividCamera & cam)
+  {
+    auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
+    auto resp = std::make_shared<std_srvs::srv::Trigger::Response>();
+    cam.captureServiceHandler(nullptr, req, resp);
+    if(!resp->success)
+    {
+      throw std::runtime_error(resp->message);
+    }
+  }
+
+  static void capture2D(ZividCamera & cam)
+  {
+    auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
+    auto resp = std::make_shared<std_srvs::srv::Trigger::Response>();
+    cam.capture2DServiceHandler(nullptr, req, resp);
+    if(!resp->success)
+    {
+      throw std::runtime_error(resp->message);
+    }
+  }
+
+  static bool isConnected(ZividCamera & cam)
+  {
+    auto req = std::make_shared<zivid_interfaces::srv::IsConnected::Request>();
+    auto resp = std::make_shared<zivid_interfaces::srv::IsConnected::Response>();
+    cam.isConnectedServiceHandler(nullptr, req, resp);
+    return resp->is_connected;
+  }
+
+  static void captureAndSave(ZividCamera & cam, const std::string & file_path)
+  {
+    auto req = std::make_shared<zivid_interfaces::srv::CaptureAndSave::Request>();
+    req->file_path = file_path;
+    auto resp = std::make_shared<zivid_interfaces::srv::CaptureAndSave::Response>();
+    cam.captureAndSaveServiceHandler(nullptr, req, resp);
+    if(!resp->success)
+    {
+      throw std::runtime_error(resp->message);
+    }
+  }
+
+  static std::string captureAssistantSuggestSettings(
+    ZividCamera & cam,
+    double max_capture_time = 1.0,
+    uint8_t ambient_light_frequency =
+      zivid_interfaces::srv::CaptureAssistantSuggestSettings::Request::AMBIENT_LIGHT_FREQUENCY_NONE)
+  {
+    auto req = std::make_shared<zivid_interfaces::srv::CaptureAssistantSuggestSettings::Request>();
+    req->max_capture_time.sec = static_cast<int32_t>(max_capture_time);
+    req->max_capture_time.nanosec = static_cast<uint32_t>((max_capture_time - req->max_capture_time.sec) * 1e9);
+    req->ambient_light_frequency = ambient_light_frequency;
+    auto resp = std::make_shared<zivid_interfaces::srv::CaptureAssistantSuggestSettings::Response>();
+    cam.captureAssistantSuggestSettingsServiceHandler(nullptr, req, resp);
+    if(!resp->success)
+    {
+      throw std::runtime_error(resp->message);
+    }
+    return resp->suggested_settings;
+  }
+
+  static std::string cameraInfoModelName(ZividCamera & cam)
+  {
+    auto req = std::make_shared<zivid_interfaces::srv::CameraInfoModelName::Request>();
+    auto resp = std::make_shared<zivid_interfaces::srv::CameraInfoModelName::Response>();
+    cam.cameraInfoModelNameServiceHandler(nullptr, req, resp);
+    return resp->model_name;
+  }
+
+  static std::string cameraInfoSerialNumber(ZividCamera & cam)
+  {
+    auto req = std::make_shared<zivid_interfaces::srv::CameraInfoSerialNumber::Request>();
+    auto resp = std::make_shared<zivid_interfaces::srv::CameraInfoSerialNumber::Response>();
+    cam.cameraInfoSerialNumberServiceHandler(nullptr, req, resp);
+    return resp->serial_number;
+  }
+};
+
+PYBIND11_MODULE(zivid_camera_pybind, m)
+{
+  py::class_<ZividCamera, std::shared_ptr<ZividCamera>>(m, "ZividCamera")
+      .def(py::init([]() {
+        rclcpp::NodeOptions options;
+        return std::make_shared<ZividCamera>(options);
+      }))
+      .def("capture", &ZividCameraPrivateAccess::capture)
+      .def("capture_2d", &ZividCameraPrivateAccess::capture2D)
+      .def("is_connected", &ZividCameraPrivateAccess::isConnected)
+      .def(
+        "capture_and_save",
+        &ZividCameraPrivateAccess::captureAndSave,
+        py::arg("file_path"))
+      .def(
+        "capture_assistant_suggest_settings",
+        &ZividCameraPrivateAccess::captureAssistantSuggestSettings,
+        py::arg("max_capture_time") = 1.0,
+        py::arg("ambient_light_frequency") =
+          zivid_interfaces::srv::CaptureAssistantSuggestSettings::Request::AMBIENT_LIGHT_FREQUENCY_NONE)
+      .def("camera_info_model_name", &ZividCameraPrivateAccess::cameraInfoModelName)
+      .def(
+        "camera_info_serial_number",
+        &ZividCameraPrivateAccess::cameraInfoSerialNumber);
+}
+

--- a/zivid_samples/scripts/sample_pybind_usage.py
+++ b/zivid_samples/scripts/sample_pybind_usage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import zivid_camera_pybind
+
+
+def main():
+    cam = zivid_camera_pybind.ZividCamera()
+    if not cam.is_connected():
+        print("Camera not connected")
+        return
+
+    print("Model:", cam.camera_info_model_name())
+    print("Serial:", cam.camera_info_serial_number())
+    cam.capture()
+    cam.capture_2d()
+    cam.capture_and_save("/tmp/sample_pybind.zdf")
+    yaml = cam.capture_assistant_suggest_settings()
+    print("Suggested settings length:", len(yaml))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pybind11_vendor dependency for `zivid_camera`
- expose C++ interface for Python and build a `zivid_camera_pybind` module
- document new Python bindings with a usage example
- provide a sample Python script using the bindings
- expand pybind module to cover additional services used by samples

## Testing
- `colcon test --packages-select zivid_camera` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ad57d85d8832e932b5a9d36f820f9